### PR TITLE
Fix: Install command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ To use this template, add `--template quality-ts` when creating a new app.
 For example:
 
 ```
-npx create-react-app my-app --template husky-ts
+npx create-react-app my-app --template quality-ts
 
 # or
 
-yarn create react-app my-app --template husky-ts
+yarn create react-app my-app --template quality-ts
 ```


### PR DESCRIPTION
The template name is `quality-ts` but the template name in the command
is `husky-ts`.\
Changing the name in the README.md file fixes the problem.